### PR TITLE
Hot fix to speed up pdf parsing

### DIFF
--- a/server/find_knn.py
+++ b/server/find_knn.py
@@ -27,8 +27,8 @@ def get_neighbors(user_doi):
 
     content = get_doi_content(user_doi)
     server_log(f"Downloaded PDF content of {user_doi}")
-
     query_vec = parse_content(content)
+
     server_log(f"Start searching {user_doi}")
 
     paper_knn = get_paper_knn(query_vec)
@@ -97,3 +97,7 @@ def get_paper_knn(query_vec):
 
     paper_knn = sorted(paper_knn, key=lambda k: k['distance'])[:10]
     return paper_knn
+
+if __name__=="__main__":
+    #get_neighbors("10.1101/2020.06.16.154674")
+    get_neighbors("10.1101/566455")

--- a/server/find_knn.py
+++ b/server/find_knn.py
@@ -97,7 +97,3 @@ def get_paper_knn(query_vec):
 
     paper_knn = sorted(paper_knn, key=lambda k: k['distance'])[:10]
     return paper_knn
-
-if __name__=="__main__":
-    #get_neighbors("10.1101/2020.06.16.154674")
-    get_neighbors("10.1101/566455")

--- a/server/word_vectors.py
+++ b/server/word_vectors.py
@@ -3,7 +3,6 @@ import pickle
 from io import BytesIO, StringIO
 from gensim.parsing.preprocessing import remove_stopwords
 from pdfminer.high_level import extract_text, extract_text_to_fp
-import time
 
 word_model_wv = pickle.load(open('data/word2vec_model/word_model.wv.pkl', 'rb'))
 
@@ -21,7 +20,7 @@ def parse_content(content, maxpages=999):
     
     # Use this function to write pdf text to the file stream
     extract_text_to_fp(
-        BytesIO(content), out, 
+        BytesIO(content), text_to_process, 
         disable_caching=True, maxpages=maxpages
     )
     

--- a/server/word_vectors.py
+++ b/server/word_vectors.py
@@ -1,12 +1,13 @@
 import numpy as np
 import pickle
-from io import BytesIO
+from io import BytesIO, StringIO
 from gensim.parsing.preprocessing import remove_stopwords
-from pdfminer.high_level import extract_text
+from pdfminer.high_level import extract_text, extract_text_to_fp
+import time
 
 word_model_wv = pickle.load(open('data/word2vec_model/word_model.wv.pkl', 'rb'))
 
-def parse_content(content):
+def parse_content(content, maxpages=999):
     """
     Parses input content and returns a vector based on the pre-loaded
     `word_model_wv`.
@@ -14,9 +15,18 @@ def parse_content(content):
     Args:
         content - a PDF file's contents to be parsed
     """
-
-    text_to_process = extract_text(BytesIO(content))
-    lines = text_to_process.lower().split("\n")
+    
+    # Have a faux file stream for parsing
+    text_to_process = StringIO()
+    
+    # Use this function to write pdf text to the file stream
+    extract_text_to_fp(
+        BytesIO(content), out, 
+        disable_caching=True, maxpages=maxpages
+    )
+    
+    # Convert text to word vectors and continue processing
+    lines = text_to_process.getvalue().lower().split("\n")
 
     word_vectors = []
     for line in lines:


### PR DESCRIPTION
This fix speeds up the PDF processing time by an exponential fold. 

`10.1101/2020.07.31.231381` went from minutes to 11 seconds
`10.1101/566455` went from 20 minutes to 2.9 minutes

The caching pdfminer does is what causes a large lag in time. The software has a bug within the `extract_text` function. Even if you put caching=False the program still uses caching and slows thing down. Instead of waiting for the package to be updated switching functions makes life easier for the time being. Lastly, I added a maxpage parameter, so if 2.9 minutes is too long we can tell pdfminer to only parse X pages to speed things up.