### PR TITLE
improve errors, boost map, and other small changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
- CI: true
+ CI: false
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
         run: yarn install
         working-directory: frontend
       - name: Build app
-        run: CI=false yarn build
+        run: yarn build
         working-directory: frontend
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -9,21 +9,17 @@ import SimilarPapers from './similar-papers';
 import MapSection from './map-section';
 import About from './about';
 import Footer from './footer';
+import { empty } from './status';
 
 import './app.css';
-
-import { empty } from './status';
 
 // main app component
 
 export default () => {
-  // data status
-  const [status, setStatus] = useState(empty);
-
   // main data
-  const [preprint, setPreprint] = useState('');
-  const [similarJournals, setSimilarJournals] = useState([]);
-  const [similarPapers, setSimilarPapers] = useState([]);
+  const [preprint, setPreprint] = useState(empty);
+  const [similarJournals, setSimilarJournals] = useState(empty);
+  const [similarPapers, setSimilarPapers] = useState(empty);
   const [coordinates, setCoordinates] = useState({});
 
   // render
@@ -34,25 +30,21 @@ export default () => {
         <Search
           {...{
             preprint,
+            similarJournals,
+            similarPapers,
             setPreprint,
-            status,
-            setStatus,
             setSimilarJournals,
             setSimilarPapers,
             setCoordinates
           }}
         />
         <hr />
-        {status !== empty && (
-          <>
-            <PreprintInfo {...{ preprint, status }} />
-            <hr />
-            <SimilarPapers {...{ similarPapers, status }} />
-            <hr />
-            <SimilarJournals {...{ similarJournals, status }} />
-            <hr />
-          </>
-        )}
+        <PreprintInfo {...{ preprint }} />
+        <hr />
+        <SimilarPapers {...{ similarPapers }} />
+        <hr />
+        <SimilarJournals {...{ similarJournals }} />
+        <hr />
         <MapSection {...{ coordinates }} />
         <hr />
         <About />

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -32,6 +32,8 @@ const backendServer = 'https://api-journal-rec.greenelab.com/doi/';
 export const getNeighbors = async (query) => {
   // look up data from backend
   const response = await fetch(backendServer + query);
+  if (!response.ok)
+    throw new Error();
   const neighbors = await response.json();
 
   // if error returned, throw error with message

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -1,10 +1,14 @@
+import { CustomError } from './error';
+
 const crossRef = 'https://api.crossref.org/works/';
 
 // look up metadata info for queried preprint from crossref
 export const getPreprintInfo = async (query) => {
   // look up info
-  const { message: info } = await (await fetch(crossRef + query)).json();
-  console.log('Preprint info:', info);
+  const response = await fetch(crossRef + query);
+  if (!response.ok)
+    throw new Error();
+  const info = (await response.json()).message;
 
   // rename and normalize props
   const preprint = {
@@ -27,7 +31,12 @@ const backendServer = 'https://api-journal-rec.greenelab.com/doi/';
 // get neighbor and coordinate data from backend
 export const getNeighbors = async (query) => {
   // look up data from backend
-  const neighbors = await (await fetch(backendServer + query)).json();
+  const response = await fetch(backendServer + query);
+  const neighbors = await response.json();
+
+  // if error returned, throw error with message
+  if (neighbors.message)
+    throw new CustomError(neighbors.message);
 
   // extract results
   const similarJournals = neighbors.journal_neighbors || [];

--- a/frontend/src/cell-details.js
+++ b/frontend/src/cell-details.js
@@ -7,7 +7,7 @@ import './cell-details.css';
 // details of selected cell component
 
 export default ({ selectedCell, selectedPc, setSelectedPc }) => (
-  <div>
+  <>
     <h4>Papers</h4>
     <p>{selectedCell.count.toLocaleString()}</p>
     <h4>Top Journals</h4>
@@ -35,5 +35,5 @@ export default ({ selectedCell, selectedPc, setSelectedPc }) => (
         </span>
       ))}
     </p>
-  </div>
+  </>
 );

--- a/frontend/src/error.js
+++ b/frontend/src/error.js
@@ -1,0 +1,6 @@
+export class CustomError extends Error {
+  constructor(...args) {
+    super(...args);
+    this.name = 'CustomError';
+  }
+}

--- a/frontend/src/map.css
+++ b/frontend/src/map.css
@@ -12,11 +12,9 @@
 }
 .cell[data-selected='true'] {
   stroke: var(--black);
-  stroke-width: 0.1;
 }
 .marker {
   fill: var(--red);
   stroke: var(--black);
-  stroke-width: 0.1;
   pointer-events: none;
 }

--- a/frontend/src/map.js
+++ b/frontend/src/map.js
@@ -9,11 +9,14 @@ import { pcColorC } from './map-section';
 import { countColorA } from './map-section';
 import { countColorB } from './map-section';
 import { getPcNum } from './map-section';
+import { boost } from './math';
 
 import './map.css';
 
 // size of map cells in svg units. match to bin width of plot data
-const cellSize = 0.85 + 0.01;
+let cellSize = 0.85;
+// increase by small % to reduce anti-alias gaps between cells
+cellSize *= 1.02;
 
 // map component
 
@@ -35,8 +38,10 @@ export default ({
     const counts = cells.map((cell) => cell.count);
     const minCount = Math.min(...counts);
     const maxCount = Math.max(...counts);
-    for (const cell of cells)
+    for (const cell of cells) {
       cell.strength = (cell.count - minCount) / (maxCount - minCount);
+      cell.strength = boost(cell.strength, 1);
+    }
   } else {
     // if pc selected, color cells by pc score
     // normalize pc scores
@@ -81,6 +86,7 @@ export default ({
                   ) :
                   countColorB.mix(countColorA, cell.strength)
               }
+              strokeWidth={cellSize / 4}
               onClick={() =>
                 cell === selectedCell ?
                   setSelectedCell(null) :
@@ -92,6 +98,7 @@ export default ({
         {coordinates.x && coordinates.y && (
           <circle
             className='marker'
+            strokeWidth={cellSize / 4}
             cx={coordinates.x}
             cy={coordinates.y}
             r={cellSize / 2}

--- a/frontend/src/map.js
+++ b/frontend/src/map.js
@@ -95,7 +95,8 @@ export default ({
             />
           ))
         }
-        {coordinates.x && coordinates.y && (
+        {typeof coordinates.x === 'number' &&
+          typeof coordinates.y === 'number' && (
           <circle
             className='marker'
             strokeWidth={cellSize / 4}

--- a/frontend/src/math.js
+++ b/frontend/src/math.js
@@ -1,0 +1,32 @@
+// limit value between min and max values
+const limit = (value, min, max) => Math.max(Math.min(value, max), min);
+
+// shorthands for math functions
+const sq = (x) => Math.pow(x, 2);
+const rt = (x) => Math.sqrt(x);
+
+// boost a normalized (0 to 1) value in non-linear, "circular" way
+// see comments below. middle values will be boosted more than extreme values.
+export const boost = (x, knee = 0) => {
+  // limit inputs
+  x = limit(x, 0, 1);
+  knee = limit(knee, 0.00001, 1);
+
+  // find formula for center (x,y) of circle given 2 points and radius:
+  // https://stackoverflow.com/questions/36211171/finding-center-of-a-circle-given-two-points-and-radius
+
+  // set (x1,y1) and (x2,y2) to (0,0) and (1,1):
+  // (x-0.5-0.5sqrt(2r^2-1))^2/r^2 + (y-0.5+0.5sqrt(2r^2-1))^2/r^2 = 1
+
+  // graph the equation on desmos.com to understand what this boost func does:
+  // \frac{\left(x-\ 0.5-0.5\sqrt{2r^{2}-1}\right)^{2}}{r^{2}}+\frac{\left(y-0.5+0.5\sqrt{2r^{2}-1}\right)^{2}}{r^{2}}=1\ \left\{0<x<1\right\}\ \left\{0<y<1\right\}
+
+  // knee will determine radius:
+  // 0% knee = infinite radius = straight line from (0,0) to (1,1)
+  // 100% knee = radius of 1 = quarter circle from (0,0) to (1,1)
+  const r = 1 / knee;
+
+  // solve previous formula for x with WolframAlpha and simplify
+  const a = rt(2 * sq(r) - 1);
+  return (1 + rt(2) * rt(2 * x * a + sq(r) - a - 2 * sq(x) + 2 * x) - a) / 2;
+};

--- a/frontend/src/preprint-info.js
+++ b/frontend/src/preprint-info.js
@@ -4,31 +4,31 @@ import Status from './status';
 
 // preprint info section
 
-export default ({ preprint, status }) => (
+export default ({ preprint }) => (
   <section id='your-preprint'>
     <h3>
       <i className='fas fa-feather-alt heading_icon'></i>Your Preprint
     </h3>
-    {Object.keys(preprint).length === 0 && <Status {...{ status }} />}
-    {Object.keys(preprint).length !== 0 && (
+    {typeof preprint === 'string' && <Status message={preprint} />}
+    {typeof preprint === 'object' && Object.keys(preprint).length !== 0 && (
       <p>
         <a href={preprint.url} title={preprint.title} className='card_detail'>
           {preprint.title}
         </a>
-        <div
+        <span
           title={preprint.authors}
           className='card_detail truncate'
           tabIndex='0'
         >
           {preprint.authors}
-        </div>
-        <div
+        </span>
+        <span
           title={preprint.journal + ' · ' + preprint.year}
           className='card_detail truncate'
           tabIndex='0'
         >
           {preprint.journal} · {preprint.year}
-        </div>
+        </span>
       </p>
     )}
   </section>

--- a/frontend/src/preprint-info.js
+++ b/frontend/src/preprint-info.js
@@ -10,7 +10,7 @@ export default ({ preprint }) => (
       <i className='fas fa-feather-alt heading_icon'></i>Your Preprint
     </h3>
     {typeof preprint === 'string' && <Status message={preprint} />}
-    {typeof preprint === 'object' && Object.keys(preprint).length !== 0 && (
+    {typeof preprint === 'object' && (
       <p>
         <a href={preprint.url} title={preprint.title} className='card_detail'>
           {preprint.title}

--- a/frontend/src/similar-journals.js
+++ b/frontend/src/similar-journals.js
@@ -3,7 +3,6 @@ import React from 'react';
 import color from 'color';
 
 import Status from './status';
-import { success } from './status';
 
 import './card.css';
 
@@ -14,13 +13,15 @@ const googleLink = 'https://www.google.com/search?q=';
 
 // similar journals section
 
-export default ({ similarJournals, status }) => (
+export default ({ similarJournals }) => (
   <section id='similar-journals'>
     <h3>
       <i className='fas fa-bookmark heading_icon'></i>Most Similar Journals
     </h3>
-    {status !== success && <Status {...{ status }} />}
-    {status === success &&
+    {typeof similarJournals === 'string' && (
+      <Status message={similarJournals} />
+    )}
+    {Array.isArray(similarJournals) &&
       similarJournals.map(({ journal, rank, distance, strength }, index) => (
         <div key={index} className='card'>
           <div

--- a/frontend/src/similar-papers.js
+++ b/frontend/src/similar-papers.js
@@ -3,7 +3,6 @@ import React from 'react';
 import color from 'color';
 
 import Status from './status';
-import { success } from './status';
 
 import './card.css';
 
@@ -14,13 +13,13 @@ const paperLink = 'https://www.ncbi.nlm.nih.gov/pmc/articles/';
 
 // related papers section
 
-export default ({ similarPapers, status }) => (
+export default ({ similarPapers }) => (
   <section id='similar-papers'>
     <h3>
       <i className='fas fa-scroll heading_icon'></i>Most Similar Papers
     </h3>
-    {status !== success && <Status {...{ status }} />}
-    {status === success &&
+    {typeof similarPapers === 'string' && <Status message={similarPapers} />}
+    {Array.isArray(similarPapers) &&
       similarPapers.map(
         (
           { id, title, authors, year, journal, rank, distance, strength },

--- a/frontend/src/status.css
+++ b/frontend/src/status.css
@@ -1,6 +1,6 @@
-.loading * {
+.gray * {
   color: var(--gray);
 }
-.error * {
+.red * {
   color: var(--red);
 }

--- a/frontend/src/status.js
+++ b/frontend/src/status.js
@@ -3,35 +3,34 @@ import React from 'react';
 import './status.css';
 
 // status key codes
-export const empty = '';
+export const empty = 'EMPTY';
 export const loading = 'LOADING';
-export const error = 'ERROR';
-export const success = 'SUCCESS';
 
 // loading/error message component
 
-export default ({ status }) => {
-  if (status === loading) {
+export default ({ message }) => {
+  if (message === empty) {
     return (
-      <section className='center'>
-        <div className='loading'>
-          <i className='fas fa-spinner fa-spin icon_with_text'></i>
-          <span>Loading...</span>
-        </div>
+      <section className='center gray'>
+        <i className='fas fa-exclamation icon_with_text'></i>
+        <span>Search for a doi</span>
       </section>
     );
   }
 
-  if (status === error) {
+  if (message === loading) {
     return (
-      <section className='center'>
-        <div className='error'>
-          <i className='far fa-times-circle icon_with_text'></i>
-          <span>Couldn't get results</span>
-        </div>
+      <section className='center gray'>
+        <i className='fas fa-spinner fa-spin icon_with_text'></i>
+        <span>Loading...</span>
       </section>
     );
   }
 
-  return null;
+  return (
+    <section className='center red'>
+      <i className='far fa-times-circle icon_with_text'></i>
+      <span>{message || "Couldn't get results"}</span>
+    </section>
+  );
 };


### PR DESCRIPTION
- improve error messages given to user and to Sentry
- simplify loading/error/empty/etc statuses of each section
- previously, if any part backend queries failed, it just showed one error and didn't show any results. now, if the preprint fails, it will just show an error for that section, and still show results for anything else that was successful.
- add math to "signal boost" map count colors
- make map stroke widths based on cell size
- fix github actions ci flag

![ezgif-4-e5941c4da2bf](https://user-images.githubusercontent.com/8326331/93381472-b6f64b80-f82e-11ea-8461-e4c73a131ec2.gif)
